### PR TITLE
Ignore internal routing when using Cmd-click

### DIFF
--- a/frontend/util/routing.js
+++ b/frontend/util/routing.js
@@ -65,7 +65,7 @@ export function path(state={path:[], query:{}}, action) {
 
 export function go(event) {
     let val = deserialize(event.currentTarget.href)
-    if(event.ctrlKey) {
+    if(event.ctrlKey || event.metaKey) {
         return
     }
     if(event) {


### PR DESCRIPTION
Safari and Firefox send click events with `.metaKey = true` when Cmd is pressed (unlike Chrome, which is _special_ and sends them with `.ctrlKey = true`)